### PR TITLE
upgrade broccoli to ^1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "author": "Stefan Pfaffel",
   "license": "MIT",
   "devDependencies": {
-    "broccoli": "^0.16.9",
+    "broccoli": "^1.1.1",
     "chai": "^3.5.0",
     "chai-spies": "^0.7.1",
     "conventional-changelog-cli": "^1.2.0",


### PR DESCRIPTION
I noticed in a local project that broccoli-livereload stopped working for me after I upgraded some dependencies. I haven't investigated it very closely, but upgrading broccoli-livereload's dependency on `broccoli` to the latest `^1.1.1` fixed that issue for me.