### PR TITLE
handling encodings correctly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,8 +10,6 @@ const livereload = require('livereload')
 class BroccoliLivereload extends BroccoliFilter {
 
     constructor(inputNodes, options) {
-        options.inputEncoding = 'binary'
-        options.outputEncoding = 'binary'
 
         super(inputNodes, options)
 

--- a/lib/injector.js
+++ b/lib/injector.js
@@ -15,7 +15,7 @@ class Injector {
     }
 
     inject(contents) {
-        const document = Document.fromString(contents.toString('utf-8'))
+        const document = Document.fromString(contents)
         document.head().appendChild(this._tag)
 
         return toBuffer(document.toHtml() + '')


### PR DESCRIPTION
Hello, when using broccoli-livereload, served HTML pages seem not to respect the original file encodings. I think these changes should fix it.