### PR TITLE
Notify LiveReload on all changed files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,8 +16,6 @@ class BroccoliLivereload extends BroccoliFilter {
 
         this._building = process.argv.indexOf('build') > 0
         this._serving = process.argv.indexOf('serve') > 0
-        this._processedFiles = {},
-        this._changedFiles = [],
 
         options.options = options.options || {}
         options.options.port = options.options.port || 35729
@@ -37,37 +35,16 @@ class BroccoliLivereload extends BroccoliFilter {
             return contents
         }
 
-        // Check if file contents has changed from previous build
-        if (this._serving) {
-            if (this._processedFiles[path] && !this._processedFiles[path].equals(contents)) {
-                this._changedFiles.push(path)
-            }
-            
-            // Cache content
-            this._processedFiles[path] = contents
-        }
+        // Notify live reload server that file changed
+        this._livereload.filterRefresh(path)
 
         const inject = this._injector.matches(path)
 
         if (inject) {
             return this._injector.inject(contents)
-        } else {
-            return contents
         }
-    }
 
-    build() {
-        return super.build().then(() => {
-            if (!this._serving || !this._livereload) {
-                return
-            }
-
-            this._changedFiles.forEach(file => {
-                this._livereload.filterRefresh(file)
-            })
-
-            this._changedFiles = [];
-        })
+        return contents
     }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,12 +16,18 @@ class BroccoliLivereload extends BroccoliFilter {
 
         this._building = process.argv.indexOf('build') > 0
         this._serving = process.argv.indexOf('serve') > 0
+        this._processedFiles = {},
+        this._changedFiles = [],
 
-        this._livereloadPort = options.options && options.options.port || 35729
+        options.options = options.options || {}
+        options.options.port = options.options.port || 35729
+        options.options.delay = options.options.delay || 100 // debounce changes
+
+        this._livereloadPort = options.options.port
         this._injector = new Injector(options.target, tag(this._livereloadPort))
 
-        if (this._serving) {
-            this._livereload = livereload.createServer(options.options)
+        if (this._serving) {           
+            this._livereload = livereload.createServer(options.options)           
         }
     }
 
@@ -31,7 +37,15 @@ class BroccoliLivereload extends BroccoliFilter {
             return contents
         }
 
-        this._lastRefreshed = path
+        // Check if file contents has changed from previous build
+        if (this._serving) {
+            if (this._processedFiles[path] && !this._processedFiles[path].equals(contents)) {
+                this._changedFiles.push(path)
+            }
+            
+            // Cache content
+            this._processedFiles[path] = contents
+        }
 
         const inject = this._injector.matches(path)
 
@@ -41,12 +55,19 @@ class BroccoliLivereload extends BroccoliFilter {
             return contents
         }
     }
-
+    
     build() {
-
+        
         return super.build().then(() => {
+            if (!this._serving || !this._livereload) {
+                return
+            }
 
-            this._serving && this._livereload.filterRefresh(this._lastRefreshed)
+            this._changedFiles.forEach(file => {
+                this._livereload.filterRefresh(file)
+            })
+
+            this._changedFiles = [];
         })
     }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,8 +26,8 @@ class BroccoliLivereload extends BroccoliFilter {
         this._livereloadPort = options.options.port
         this._injector = new Injector(options.target, tag(this._livereloadPort))
 
-        if (this._serving) {           
-            this._livereload = livereload.createServer(options.options)           
+        if (this._serving) {
+            this._livereload = livereload.createServer(options.options)
         }
     }
 
@@ -55,9 +55,8 @@ class BroccoliLivereload extends BroccoliFilter {
             return contents
         }
     }
-    
+
     build() {
-        
         return super.build().then(() => {
             if (!this._serving || !this._livereload) {
                 return


### PR DESCRIPTION
LiveReload currently is only notified about the last changed file, due to the `_lastRefreshed` property.
This change stores any changed files and notifies the LiveReload server of all changed files, with a delay of 100ms to act as a debounce if multiple files changed (i.e. source maps etc).

I noticed that my sourcemap file was being passed to LiveReload as the change file, and thus it was not reloading when changing my scss file. Dug into it and it seems to be due to passing only the last file of the input files, rather than the files that have actually changed.

This could be further optimized by filtering files by the same extensions that LiveReload is also filtering.