### PR TITLE
Dont add reload tag unless <head>

### DIFF
--- a/lib/injector.js
+++ b/lib/injector.js
@@ -16,7 +16,10 @@ class Injector {
 
     inject(contents) {
         const document = Document.fromString(contents.toString('utf-8'))
-        document.head().appendChild(this._tag)
+        const head = document.head();
+        if (head) {
+            head.appendChild(this._tag)
+        }
 
         return toBuffer(document.toHtml() + '')
     }


### PR DESCRIPTION
This fix's exceptions that might be thrown if a fragment of `html` that lack `<head>` tags are processed.